### PR TITLE
Update timestamp when we encounter a peer more than once and it has a higher timestamp

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -85,7 +85,7 @@ class ChiaNetworkScanner {
             peerLogger.debug('Skipping already visited peer');
 
             if (proposedPeer.timestamp > peer.timestamp) {
-                log.debug(`Updating visited peer ${proposedPeer.hostname}:${proposedPeer.port} to more recent timestamp`);
+                peerLogger.debug(`Updating visited peer to more recent timestamp`);
 
                 this.peers.set(peerHash, proposedPeer);
             }

--- a/index.ts
+++ b/index.ts
@@ -84,6 +84,12 @@ class ChiaNetworkScanner {
         if (peer.visited) {
             peerLogger.debug('Skipping already visited peer');
 
+            if (proposedPeer.timestamp > peer.timestamp) {
+                log.debug(`Updating visited peer ${proposedPeer.hostname}:${proposedPeer.port} to more recent timestamp`);
+
+                this.peers.set(peerHash, proposedPeer);
+            }
+
             return;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-network-scanner",
-  "version": "5.0.9",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-network-scanner",
-  "version": "5.0.9",
+  "version": "5.1.0",
   "description": "Scans the Chia network for active full nodes",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
**Previous behaviour**

When we encounter a peer that we have already traversed it is immediately discarded and we move onto the next peer.

**New behaviour**

When we encounter a peer that we have already traversed we check to see if the new version of that peer has a higher timestamp, if it does we update our record of the peer to have the more recent timestamp. We still do not traverse the peer a second time.